### PR TITLE
only show modules that leads to a set of dependencies (#9)

### DIFF
--- a/src/main/java/com/github/ferstl/depgraph/AbstractGraphMojo.java
+++ b/src/main/java/com/github/ferstl/depgraph/AbstractGraphMojo.java
@@ -127,6 +127,14 @@ abstract class AbstractGraphMojo extends AbstractMojo {
   @Parameter(property = "dotExecutable")
   private File dotExecutable;
 
+  /**
+   * List of artifacts, in the form of {@code groupId:artifactId:type:classifier}, to restrict the dependency
+   * graph only to artefacts that depend on them.
+   *
+   * @since 1.0.4
+   */
+  @Parameter(property = "targetDependencies", defaultValue = "")
+  List<String> targetDependencies;
 
 
   /**

--- a/src/main/java/com/github/ferstl/depgraph/AggregatingDependencyGraphByGroupIdMojo.java
+++ b/src/main/java/com/github/ferstl/depgraph/AggregatingDependencyGraphByGroupIdMojo.java
@@ -42,7 +42,7 @@ public class AggregatingDependencyGraphByGroupIdMojo extends AbstractGraphMojo {
         .useNodeLabelRenderer(NodeRenderers.GROUP_ID_LABEL)
         .omitSelfReferences();
 
-    GraphBuilderAdapter adapter = new GraphBuilderAdapter(this.dependencyGraphBuilder);
+    GraphBuilderAdapter adapter = new GraphBuilderAdapter(this.dependencyGraphBuilder, this.targetDependencies);
     return new AggregatingGraphFactory(adapter, artifactFilter, dotBuilder, true);
   }
 }

--- a/src/main/java/com/github/ferstl/depgraph/AggregatingDependencyGraphMojo.java
+++ b/src/main/java/com/github/ferstl/depgraph/AggregatingDependencyGraphMojo.java
@@ -66,7 +66,7 @@ public class AggregatingDependencyGraphMojo extends AbstractGraphMojo {
       .useNodeRenderer(NodeRenderers.VERSIONLESS_ID)
       .useNodeLabelRenderer(determineNodeLabelRenderer());
 
-    GraphBuilderAdapter adapter = new GraphBuilderAdapter(this.dependencyGraphBuilder);
+    GraphBuilderAdapter adapter = new GraphBuilderAdapter(this.dependencyGraphBuilder, this.targetDependencies);
 
     return new AggregatingGraphFactory(adapter, artifactFilter, dotBuilder, this.includeParentProjects);
   }

--- a/src/main/java/com/github/ferstl/depgraph/DependencyGraphByGroupIdMojo.java
+++ b/src/main/java/com/github/ferstl/depgraph/DependencyGraphByGroupIdMojo.java
@@ -37,7 +37,7 @@ public class DependencyGraphByGroupIdMojo extends AbstractGraphMojo {
   protected GraphFactory createGraphFactory(ArtifactFilter artifactFilter) {
     DotBuilder dotBuilder = createGraphBuilder();
 
-    GraphBuilderAdapter adapter = new GraphBuilderAdapter(this.dependencyTreeBuilder, this.localRepository);
+    GraphBuilderAdapter adapter = new GraphBuilderAdapter(this.dependencyTreeBuilder, this.localRepository, this.targetDependencies);
     return new SimpleGraphFactory(adapter, artifactFilter, dotBuilder);
   }
 

--- a/src/main/java/com/github/ferstl/depgraph/DependencyGraphMojo.java
+++ b/src/main/java/com/github/ferstl/depgraph/DependencyGraphMojo.java
@@ -98,9 +98,9 @@ public class DependencyGraphMojo extends AbstractGraphMojo {
   private GraphBuilderAdapter createGraphBuilderAdapter() {
     GraphBuilderAdapter adapter;
     if (requiresFullGraph()) {
-      adapter = new GraphBuilderAdapter(this.dependencyTreeBuilder, this.localRepository);
+      adapter = new GraphBuilderAdapter(this.dependencyTreeBuilder, this.localRepository, this.targetDependencies);
     } else {
-      adapter = new GraphBuilderAdapter(this.dependencyGraphBuilder);
+      adapter = new GraphBuilderAdapter(this.dependencyGraphBuilder, this.targetDependencies);
     }
     return adapter;
   }

--- a/src/main/java/com/github/ferstl/depgraph/DotBuildingVisitor.java
+++ b/src/main/java/com/github/ferstl/depgraph/DotBuildingVisitor.java
@@ -35,16 +35,18 @@ class DotBuildingVisitor implements org.apache.maven.shared.dependency.graph.tra
   private final DotBuilder dotBuilder;
   private final Deque<Node> stack;
   private final ArtifactFilter artifactFilter;
+  private final ArtifactFilter targetDependencies;
 
 
-  public DotBuildingVisitor(DotBuilder dotBuilder, ArtifactFilter artifactFilter) {
+  public DotBuildingVisitor(DotBuilder dotBuilder, ArtifactFilter artifactFilter, ArtifactFilter targetDependencies) {
     this.dotBuilder = dotBuilder;
     this.stack = new ArrayDeque<>();
     this.artifactFilter = artifactFilter;
+    this.targetDependencies = targetDependencies;
   }
 
-  public DotBuildingVisitor(DotBuilder dotBuilder) {
-    this(dotBuilder, DoNothingArtifactFilter.INSTANCE);
+  public DotBuildingVisitor(DotBuilder dotBuilder, ArtifactFilter targetDependencies) {
+    this(dotBuilder, DoNothingArtifactFilter.INSTANCE, targetDependencies);
   }
 
   @Override
@@ -67,10 +69,10 @@ class DotBuildingVisitor implements org.apache.maven.shared.dependency.graph.tra
     return internalEndVisit(new DependencyNodeAdapter(node));
   }
 
-  private boolean internalVisit(Node node) {
+  private boolean internalVisit(DependencyNodeAdapter node) {
     Node currentParent = this.stack.peek();
 
-    if (this.artifactFilter.include(node.getArtifact())) {
+    if (this.artifactFilter.include(node.getArtifact()) && leadsToTargetDependencies(node)) {
       if (currentParent != null) {
         this.dotBuilder.addEdge(currentParent, node);
       }
@@ -82,16 +84,30 @@ class DotBuildingVisitor implements org.apache.maven.shared.dependency.graph.tra
 
     return false;
   }
+  
+  private boolean leadsToTargetDependencies(DependencyNodeAdapter node) {
+    if (targetDependencies.include(node.getArtifact())) {
+      return true;
+    }
+    
+    for (DependencyNodeAdapter c : node.getChildren()) {
+      if (leadsToTargetDependencies(c)) {
+        return true;
+      }
+    }
+    
+    return false;
+  }
 
-  private boolean internalEndVisit(Node node) {
-    if (this.artifactFilter.include(node.getArtifact())) {
+  private boolean internalEndVisit(DependencyNodeAdapter node) {
+    if (this.artifactFilter.include(node.getArtifact()) && leadsToTargetDependencies(node)) {
       this.stack.pop();
     }
 
     return true;
   }
 
-  private static enum DoNothingArtifactFilter implements ArtifactFilter {
+  static enum DoNothingArtifactFilter implements ArtifactFilter {
     INSTANCE;
 
     @Override

--- a/src/test/java/com/github/ferstl/depgraph/AggregatingGraphFactoryTest.java
+++ b/src/test/java/com/github/ferstl/depgraph/AggregatingGraphFactoryTest.java
@@ -15,7 +15,16 @@
  */
 package com.github.ferstl.depgraph;
 
+import static com.github.ferstl.depgraph.dot.DotBuilderMatcher.emptyGraph;
+import static com.github.ferstl.depgraph.dot.DotBuilderMatcher.hasNodesAndEdges;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
@@ -28,14 +37,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.github.ferstl.depgraph.dot.DotBuilder;
-
-import static com.github.ferstl.depgraph.dot.DotBuilderMatcher.emptyGraph;
-import static com.github.ferstl.depgraph.dot.DotBuilderMatcher.hasNodesAndEdges;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * JUnit tests for {@link AggregatingGraphFactory}.
@@ -53,6 +54,7 @@ import static org.mockito.Mockito.when;
 public class AggregatingGraphFactoryTest {
 
   private ArtifactFilter artifactFilter;
+  private List<String> targetDependencies;
   private DependencyGraphBuilder graphBuilder;
   private GraphBuilderAdapter adapter;
   private DotBuilder dotBuilder;
@@ -62,11 +64,13 @@ public class AggregatingGraphFactoryTest {
     this.artifactFilter = mock(ArtifactFilter.class);
     when(this.artifactFilter.include(Mockito.<Artifact>any())).thenReturn(true);
 
+    this.targetDependencies = new ArrayList<>();
+    
     DependencyNode dependencyNode = mock(DependencyNode.class);
     this.graphBuilder = mock(DependencyGraphBuilder.class);
     when(this.graphBuilder.buildDependencyGraph(Mockito.<MavenProject>any(), Mockito.<ArtifactFilter>any())).thenReturn(dependencyNode);
-
-    this.adapter = new GraphBuilderAdapter(this.graphBuilder);
+    
+    this.adapter = new GraphBuilderAdapter(this.graphBuilder, this.targetDependencies);
 
     this.dotBuilder = new DotBuilder();
   }

--- a/src/test/java/com/github/ferstl/depgraph/DotBuildingVisitorTest.java
+++ b/src/test/java/com/github/ferstl/depgraph/DotBuildingVisitorTest.java
@@ -15,6 +15,15 @@
  */
 package com.github.ferstl.depgraph;
 
+import static com.github.ferstl.depgraph.dot.DotBuilderMatcher.hasNodesAndEdges;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
@@ -25,27 +34,26 @@ import org.mockito.Mockito;
 
 import com.github.ferstl.depgraph.dot.DotBuilder;
 
-import static com.github.ferstl.depgraph.dot.DotBuilderMatcher.hasNodesAndEdges;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 
 public class DotBuildingVisitorTest {
 
   private DotBuilder dotBuilder;
   private DotBuildingVisitor visitor;
   private ArtifactFilter artifactFilter;
+  private ArtifactFilter targetDependencies;
 
   @Before
   public void before() {
     this.dotBuilder = new DotBuilder();
+
     this.artifactFilter = mock(ArtifactFilter.class);
     when(this.artifactFilter.include(Mockito.<Artifact>any())).thenReturn(true);
 
-    this.visitor = new DotBuildingVisitor(this.dotBuilder, this.artifactFilter);
+    // this is the same as an empty list of target dependencies
+    this.targetDependencies = mock(ArtifactFilter.class);
+    when(this.targetDependencies.include(Mockito.<Artifact>any())).thenReturn(true);
+
+    this.visitor = new DotBuildingVisitor(this.dotBuilder, this.artifactFilter, this.targetDependencies);
   }
 
   /**
@@ -56,8 +64,8 @@ public class DotBuildingVisitorTest {
    */
   @Test
   public void parentAndChild() {
-    DependencyNode parent = createGraphNode("parent");
     DependencyNode child = createGraphNode("child");
+    DependencyNode parent = createGraphNode("parent", child);
 
     assertTrue(this.visitor.visit(parent));
     assertTrue(this.visitor.visit(child));
@@ -81,9 +89,9 @@ public class DotBuildingVisitorTest {
    */
   @Test
   public void ignoredNode() {
-    DependencyNode parent = createGraphNode("parent");
     DependencyNode child1 = createGraphNode("child1");
     DependencyNode child2 = createGraphNode("child2");
+    DependencyNode parent = createGraphNode("parent", child1, child2);
 
     when(this.artifactFilter.include(child2.getArtifact())).thenReturn(false);
 
@@ -104,18 +112,51 @@ public class DotBuildingVisitorTest {
           "\"groupId:parent:jar:version:compile\" -> \"groupId:child1:jar:version:compile\""}));
   }
 
+  /**
+   * <pre>
+   * parent
+   * - child1
+   * - child2 (target dependency)
+   * </pre>
+   */
+  @Test
+  public void targetDepNode() {
+    DependencyNode child1 = createGraphNode("child1");
+    DependencyNode child2 = createGraphNode("child2");
+    DependencyNode parent = createGraphNode("parent", child1, child2);
+    
+    when(this.targetDependencies.include(Mockito.<Artifact>any())).thenReturn(false);
+    when(this.targetDependencies.include(child2.getArtifact())).thenReturn(true);
+
+    assertTrue(this.visitor.visit(parent));
+
+    // Don't process any further children of child2
+    assertFalse(this.visitor.visit(child1));
+    assertTrue(this.visitor.endVisit(child1));
+
+    assertTrue(this.visitor.visit(child2));
+    assertTrue(this.visitor.endVisit(child2));
+
+    assertThat(this.dotBuilder, hasNodesAndEdges(
+        new String[] {
+          "\"groupId:parent:jar:version:compile\"[label=\"groupId:parent:jar:version:compile\"]",
+          "\"groupId:child:jar:version:compile\"[label=\"groupId:child2:jar:version:compile\"]"},
+        new String[] {
+          "\"groupId:parent:jar:version:compile\" -> \"groupId:child2:jar:version:compile\""}));
+  }
+  
   @Test
   public void defaultArtifactFilter() {
-    this.visitor = new DotBuildingVisitor(this.dotBuilder);
+    this.visitor = new DotBuildingVisitor(this.dotBuilder, this.targetDependencies);
 
     // Use other test (I know this is ugly...)
     parentAndChild();
   }
 
-  private static org.apache.maven.shared.dependency.graph.DependencyNode createGraphNode(String artifactId) {
-    DependencyNode node = mock(org.apache.maven.shared.dependency.graph.DependencyNode.class);
+  private static DependencyNode createGraphNode(String artifactId, DependencyNode... children) {
+    DependencyNode node = mock(DependencyNode.class);
     when(node.getArtifact()).thenReturn(createArtifact(artifactId));
-
+    when(node.getChildren()).thenReturn(Arrays.asList(children));
     return node;
   }
 

--- a/src/test/java/com/github/ferstl/depgraph/GraphBuilderAdapterTest.java
+++ b/src/test/java/com/github/ferstl/depgraph/GraphBuilderAdapterTest.java
@@ -15,6 +15,15 @@
  */
 package com.github.ferstl.depgraph;
 
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.project.MavenProject;
@@ -30,12 +39,6 @@ import org.mockito.Mockito;
 
 import com.github.ferstl.depgraph.dot.DotBuilder;
 
-import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 /**
  * JUnit tests for {@link GraphBuilderAdapter}.
  */
@@ -49,10 +52,12 @@ public class GraphBuilderAdapterTest {
   private MavenProject mavenProject;
   private DotBuilder dotBuilder;
   private ArtifactFilter artifactFilter;
+  private List<String> targetDependencies;
   private ArtifactRepository artifactRepository;
 
   private GraphBuilderAdapter graphAdapter;
   private GraphBuilderAdapter treeAdapter;
+
 
   @Before
   public void before() throws Exception {
@@ -66,9 +71,11 @@ public class GraphBuilderAdapterTest {
     this.dependencyTreeBuilder = mock(DependencyTreeBuilder.class);
     when(this.dependencyTreeBuilder.buildDependencyTree(Mockito.<MavenProject>any(), Mockito.<ArtifactRepository>any(), Mockito.<ArtifactFilter>any())).thenReturn(mock(org.apache.maven.shared.dependency.tree.DependencyNode.class));
 
+    this.targetDependencies = new ArrayList<>();
+    
     this.artifactRepository = mock(ArtifactRepository.class);
-    this.graphAdapter = new GraphBuilderAdapter(this.dependencyGraphBuilder);
-    this.treeAdapter = new GraphBuilderAdapter(this.dependencyTreeBuilder, this.artifactRepository);
+    this.graphAdapter = new GraphBuilderAdapter(this.dependencyGraphBuilder, this.targetDependencies);
+    this.treeAdapter = new GraphBuilderAdapter(this.dependencyTreeBuilder, this.artifactRepository, this.targetDependencies);
   }
 
   @Test


### PR DESCRIPTION
Ok, here is a first implementation for #9 (only show modules that leads to a set of dependencies)

I decided work at the level of DotBuildingVisitor because filtering artifact earlier was too early: we need the already populated graph to be able to decide if an artifact can stay.

Also I put the transformation from List to an ArtifactFilter in GraphBuilderAdapter even though it wasn't the most obvious. I mainly did it to ease testing while keeping code simple: if I do it in AbstractGraphMojo it makes the code more complex and if I do it in DotBuildingVisitor, then it's complex to test it (because we need to odify the list after the visitor was create by the @Before...).

I put one simple test too.

Anyway, please tell me what can be improved :)