### PR TITLE
Json Format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 .iml
 .settings/org.eclipse.core.resources.prefs
 .idea/
-/target
+target

--- a/src/main/java/com/github/ferstl/depgraph/AbstractGraphMojo.java
+++ b/src/main/java/com/github/ferstl/depgraph/AbstractGraphMojo.java
@@ -51,6 +51,7 @@ import com.github.ferstl.depgraph.dependency.DotGraphStyleConfigurer;
 import com.github.ferstl.depgraph.dependency.GmlGraphStyleConfigurer;
 import com.github.ferstl.depgraph.dependency.GraphFactory;
 import com.github.ferstl.depgraph.dependency.GraphStyleConfigurer;
+import com.github.ferstl.depgraph.dependency.JsonGraphStyleConfigurer;
 import com.github.ferstl.depgraph.dependency.PumlGraphStyleConfigurer;
 import com.github.ferstl.depgraph.dependency.style.StyleConfiguration;
 import com.github.ferstl.depgraph.dependency.style.resource.BuiltInStyleResource;
@@ -120,7 +121,7 @@ abstract class AbstractGraphMojo extends AbstractMojo {
    * @since 2.1.0
    */
   @Parameter(property = "graphFormat", defaultValue = "dot")
-  private String graphFormat;
+  protected String graphFormat;
 
   /**
    * The path to the generated output file. A file extension matching the configured {@code graphFormat} will be
@@ -302,6 +303,8 @@ abstract class AbstractGraphMojo extends AbstractMojo {
         return new GmlGraphStyleConfigurer();
       case PUML:
         return new PumlGraphStyleConfigurer();
+      case JSON:
+        return new JsonGraphStyleConfigurer();
       default:
         throw new IllegalArgumentException("Unsupported output format: " + graphFormat);
     }

--- a/src/main/java/com/github/ferstl/depgraph/DependencyGraphMojo.java
+++ b/src/main/java/com/github/ferstl/depgraph/DependencyGraphMojo.java
@@ -28,7 +28,6 @@ import com.github.ferstl.depgraph.dependency.MavenGraphAdapter;
 import com.github.ferstl.depgraph.dependency.NodeResolution;
 import com.github.ferstl.depgraph.dependency.SimpleGraphFactory;
 import com.github.ferstl.depgraph.graph.GraphBuilder;
-
 import static com.github.ferstl.depgraph.dependency.NodeIdRenderers.VERSIONLESS_ID;
 import static java.util.EnumSet.allOf;
 import static java.util.EnumSet.complementOf;
@@ -102,12 +101,14 @@ public class DependencyGraphMojo extends AbstractGraphMojo {
   }
 
   private MavenGraphAdapter createMavenGraphAdapter(ArtifactFilter targetFilter) {
+    boolean jsonFormat = GraphFormat.forName(this.graphFormat) == GraphFormat.JSON;
     MavenGraphAdapter adapter;
-    if (requiresFullGraph()) {
+    if (requiresFullGraph() || jsonFormat) {
       EnumSet<NodeResolution> resolutions = allOf(NodeResolution.class);
-      resolutions = !this.showConflicts ? complementOf(of(NodeResolution.OMITTED_FOR_CONFLICT)) : resolutions;
-      resolutions = !this.showDuplicates ? complementOf(of(NodeResolution.OMITTED_FOR_DUPLICATE)) : resolutions;
-
+      if (!jsonFormat) {
+        resolutions = !this.showConflicts ? complementOf(of(NodeResolution.OMITTED_FOR_CONFLICT)) : resolutions;
+        resolutions = !this.showDuplicates ? complementOf(of(NodeResolution.OMITTED_FOR_DUPLICATE)) : resolutions;
+      }
       adapter = new MavenGraphAdapter(this.dependencyTreeBuilder, this.localRepository, targetFilter, resolutions);
     } else {
       adapter = new MavenGraphAdapter(this.dependencyGraphBuilder, targetFilter);

--- a/src/main/java/com/github/ferstl/depgraph/GraphFormat.java
+++ b/src/main/java/com/github/ferstl/depgraph/GraphFormat.java
@@ -16,7 +16,7 @@
 package com.github.ferstl.depgraph;
 
 public enum GraphFormat {
-  DOT, GML, PUML;
+  DOT, GML, PUML, JSON;
 
   public static GraphFormat forName(String name) {
     try {

--- a/src/main/java/com/github/ferstl/depgraph/dependency/JsonDependencyEdgeRenderer.java
+++ b/src/main/java/com/github/ferstl/depgraph/dependency/JsonDependencyEdgeRenderer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014 - 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.ferstl.depgraph.dependency;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.maven.artifact.Artifact;
+import com.github.ferstl.depgraph.graph.EdgeRenderer;
+import com.google.common.base.Joiner;
+
+public class JsonDependencyEdgeRenderer implements EdgeRenderer<DependencyNode> {
+
+  private static final Joiner NEWLINE_JOINER = Joiner.on("\n").skipNulls();
+  private static final Joiner COMMA_JOINER = Joiner.on(",").skipNulls();
+  private final Map<Artifact, Integer> artifactToIdMap;
+
+  public JsonDependencyEdgeRenderer(Map<Artifact, Integer> artifactToIdMap) {
+    this.artifactToIdMap = artifactToIdMap;
+  }
+
+  @Override
+  public String render(DependencyNode from, DependencyNode to) {
+    List<String> scopeStrings = new ArrayList<>();
+    for (String scope : to.getScopes()) {
+      scopeStrings.add("\"" + scope + "\"");
+    }
+
+    return NEWLINE_JOINER.join(
+        "{ \"from\": " + this.artifactToIdMap.get(from.getArtifact()),
+        "    , \"to\": " + this.artifactToIdMap.get(to.getArtifact()),
+        "    , \"resolution\": \"" + to.getResolution() + "\"",
+        "    , \"scopes\": [ " + COMMA_JOINER.join(scopeStrings) + " ]",
+        "    }");
+  }
+
+}

--- a/src/main/java/com/github/ferstl/depgraph/dependency/JsonDependencyNodeNameRenderer.java
+++ b/src/main/java/com/github/ferstl/depgraph/dependency/JsonDependencyNodeNameRenderer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2014 - 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.ferstl.depgraph.dependency;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.maven.artifact.Artifact;
+import com.github.ferstl.depgraph.graph.NodeRenderer;
+import com.google.common.base.Joiner;
+
+public class JsonDependencyNodeNameRenderer implements NodeRenderer<DependencyNode> {
+
+  private static final Joiner NEWLINE_JOINER = Joiner.on("\n").skipNulls();
+  private final AtomicInteger nextId = new AtomicInteger(0);
+  private final Map<Artifact, Integer> artifactToIdMap;
+
+  public JsonDependencyNodeNameRenderer(Map<Artifact, Integer> artifactToIdMap) {
+    this.artifactToIdMap = artifactToIdMap;
+  }
+
+  @Override
+  public String render(DependencyNode node) {
+    if (!this.artifactToIdMap.containsKey(node.getArtifact())) {
+      this.artifactToIdMap.put(node.getArtifact(), this.nextId.getAndIncrement());
+    }
+    Integer nodeId = this.artifactToIdMap.get(node.getArtifact());
+    return NEWLINE_JOINER.join(
+        "{ \"id\": " + nodeId,
+        "    , \"artifactId\": \"" + node.getArtifact().getArtifactId() + "\"",
+        "    , \"groupId\": \"" + node.getArtifact().getGroupId() + "\"",
+        "    , \"version\": \"" + node.getArtifact().getVersion() + "\"",
+        "    }");
+  }
+}

--- a/src/main/java/com/github/ferstl/depgraph/dependency/JsonGraphStyleConfigurer.java
+++ b/src/main/java/com/github/ferstl/depgraph/dependency/JsonGraphStyleConfigurer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014 - 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.ferstl.depgraph.dependency;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.maven.artifact.Artifact;
+import com.github.ferstl.depgraph.graph.GraphBuilder;
+import com.github.ferstl.depgraph.graph.json.JsonGraphFormatter;
+
+public class JsonGraphStyleConfigurer implements GraphStyleConfigurer {
+
+  @Override
+  public GraphStyleConfigurer showGroupIds(boolean showGroupId) {
+    return this;
+  }
+
+  @Override
+  public GraphStyleConfigurer showArtifactIds(boolean showArtifactId) {
+    return this;
+  }
+
+  @Override
+  public GraphStyleConfigurer showVersionsOnNodes(boolean showVersionsOnNodes) {
+    return this;
+  }
+
+  @Override
+  public GraphStyleConfigurer showVersionsOnEdges(boolean showVersionOnEdges) {
+    return this;
+  }
+
+  @Override
+  public GraphBuilder<DependencyNode> configure(GraphBuilder<DependencyNode> notUsed) {
+    Map<Artifact, Integer> artifactToIdMap = new HashMap<>();
+    return GraphBuilder.<DependencyNode>create(NodeIdRenderers.ID)
+        .useNodeNameRenderer(new JsonDependencyNodeNameRenderer(artifactToIdMap))
+        .useEdgeRenderer(new JsonDependencyEdgeRenderer(artifactToIdMap))
+        .graphFormatter(new JsonGraphFormatter());
+  }
+}

--- a/src/main/java/com/github/ferstl/depgraph/dependency/NodeIdRenderers.java
+++ b/src/main/java/com/github/ferstl/depgraph/dependency/NodeIdRenderers.java
@@ -63,6 +63,19 @@ public enum NodeIdRenderers implements NodeRenderer<DependencyNode> {
           artifact.getScope());
     }
 
+  },
+  
+  ID {
+    @Override
+    public String render(DependencyNode node) {
+      Artifact artifact = node.getArtifact();
+      return COLON_JOINER.join(
+          artifact.getGroupId(),
+          artifact.getArtifactId(),
+          artifact.getVersion(),
+          artifact.getType(),
+          artifact.getClassifier());
+    }
   };
 
   private static final Joiner COLON_JOINER = Joiner.on(":").useForNull("");

--- a/src/main/java/com/github/ferstl/depgraph/graph/json/JsonGraphFormatter.java
+++ b/src/main/java/com/github/ferstl/depgraph/graph/json/JsonGraphFormatter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2014 - 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.ferstl.depgraph.graph.json;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import com.github.ferstl.depgraph.graph.Edge;
+import com.github.ferstl.depgraph.graph.GraphFormatter;
+import com.github.ferstl.depgraph.graph.Node;
+import com.google.common.base.Joiner;
+
+public class JsonGraphFormatter implements GraphFormatter {
+
+  @Override
+  public String format(String graphName, Collection<Node<?>> nodes, Collection<Edge> edges) {
+    StringBuilder result = new StringBuilder();
+
+    // output artifacts
+    result.append("{ \"artifacts\":\n");
+    result.append("  [ ");
+    List<String> nodeStrings = new ArrayList<>();
+    for (Node<?> node : nodes) {
+      nodeStrings.add(node.getNodeName());
+    }
+    result.append(Joiner.on("\n  , ").join(nodeStrings));
+    result.append("\n  ]\n");
+
+    // output dependencies
+    result.append(", \"dependencies\":\n");
+    result.append("  [ ");
+    List<String> depenencyStrings = new ArrayList<>();
+    for (Edge edge : edges) {
+      depenencyStrings.add(edge.getName());
+    }
+    result.append(Joiner.on("\n  , ").join(depenencyStrings));
+    result.append("\n  ]\n");
+    result.append("}");
+
+    return result.toString();
+  }
+}

--- a/src/test/java/com/github/ferstl/depgraph/DocumentationIntegrationTest.java
+++ b/src/test/java/com/github/ferstl/depgraph/DocumentationIntegrationTest.java
@@ -142,6 +142,17 @@ public class DocumentationIntegrationTest {
   }
 
   @Test
+  public void aggregatedJson() throws Exception {
+    runTest("aggregate",
+        "-DgraphFormat=json",
+        "-DincludeParentProjects=true");
+
+    assertFilesPresent(this.basedir, "target/dependency-graph.json");
+
+    collectFile("target/dependency-graph.json", "aggregated.json");
+  }
+
+  @Test
   public void aggregatedByGroupId() throws Exception {
     runTest("aggregate-by-groupid");
 
@@ -182,6 +193,22 @@ public class DocumentationIntegrationTest {
         "sub-parent/target/dependency-graph.gml");
 
     collectFile("sub-parent/module-3/target/dependency-graph.gml", "with-conflicts.gml");
+  }
+
+  @Test
+  public void jsonGraph() throws Exception {
+    runTest("graph",
+        "-DgraphFormat=json");
+
+    assertFilesPresent(
+        this.basedir,
+        "module-1/target/dependency-graph.json",
+        "module-2/target/dependency-graph.json",
+        "sub-parent/module-3/target/dependency-graph.json",
+        "target/dependency-graph.json",
+        "sub-parent/target/dependency-graph.json");
+
+    collectFile("sub-parent/module-3/target/dependency-graph.json", "dependency-graph.json");
   }
 
   private void runTest(String goal, String... cliOptions) throws Exception {


### PR DESCRIPTION
Adds `json` graph format as a first step to resolve #32.
Note that options like `showConflicts` and `showDuplicates` have no effect on the output. The json always contains all information,  because it is considered that the consumer of the json files will filter the data as needed. 
For the same reason, the aggregated graph contains all dependencies, including conflicts.