### PR TITLE
add support for classifier when styling DOT graphs

### DIFF
--- a/src/main/java/com/github/ferstl/depgraph/dependency/dot/DotDependencyNodeNameRenderer.java
+++ b/src/main/java/com/github/ferstl/depgraph/dependency/dot/DotDependencyNodeNameRenderer.java
@@ -54,7 +54,7 @@ public class DotDependencyNodeNameRenderer implements NodeRenderer<DependencyNod
     String classifiers = createClassifierString(node.getClassifiers());
 
     String effectiveScope = node.getEffectiveScope();
-    StyleKey styleKey = StyleKey.create(artifact.getGroupId(), artifact.getArtifactId(), effectiveScope, artifact.getType(), node.getEffectiveVersion());
+    StyleKey styleKey = StyleKey.create(artifact.getGroupId(), artifact.getArtifactId(), effectiveScope, artifact.getType(), node.getEffectiveVersion(), classifiers);
 
     return this.styleConfiguration.nodeAttributes(
         styleKey,

--- a/src/main/java/com/github/ferstl/depgraph/dependency/dot/style/StyleConfiguration.java
+++ b/src/main/java/com/github/ferstl/depgraph/dependency/dot/style/StyleConfiguration.java
@@ -108,7 +108,7 @@ public class StyleConfiguration {
 
     // Specific edge style-from win over node resolution
     if (from != null) {
-      StyleKey artifactKeyFrom = StyleKey.create(from.getGroupId(), from.getArtifactId(), from.getScope(), from.getType(), from.getVersion());
+      StyleKey artifactKeyFrom = StyleKey.create(from.getGroupId(), from.getArtifactId(), from.getScope(), from.getType(), from.getVersion(), from.getClassifier());
       for (Entry<StyleKey, Edge> entry : this.edgeNodeStylesFrom.entrySet()) {
         StyleKey styleKey = entry.getKey();
         if (styleKey.matches(artifactKeyFrom)) {
@@ -119,7 +119,7 @@ public class StyleConfiguration {
     }
     // Specific edge style-from to over node resolution
     if (to != null) {
-      StyleKey artifactKeyTo = StyleKey.create(to.getGroupId(), to.getArtifactId(), to.getScope(), to.getType(), to.getVersion());
+      StyleKey artifactKeyTo = StyleKey.create(to.getGroupId(), to.getArtifactId(), to.getScope(), to.getType(), to.getVersion(), to.getClassifier());
       for (Entry<StyleKey, Edge> entry : this.edgeNodeStylesTo.entrySet()) {
         StyleKey styleKey = entry.getKey();
         if (styleKey.matches(artifactKeyTo)) {

--- a/src/main/java/com/github/ferstl/depgraph/dependency/dot/style/StyleKey.java
+++ b/src/main/java/com/github/ferstl/depgraph/dependency/dot/style/StyleKey.java
@@ -15,27 +15,29 @@
  */
 package com.github.ferstl.depgraph.dependency.dot.style;
 
-import java.util.Objects;
-import org.apache.commons.lang3.StringUtils;
 import com.google.common.base.Joiner;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.apache.commons.lang3.StringUtils.startsWith;
 
 public final class StyleKey {
 
-  private static final int NUM_ELEMENTS = 5;
+  private static final int NUM_ELEMENTS = 6;
 
   private final String groupId;
   private final String artifactId;
   private final String scope;
   private final String type;
   private final String version;
+  private final String classifier;
 
 
   private StyleKey(String[] parts) {
     if (parts.length > NUM_ELEMENTS) {
-      throw new IllegalArgumentException("Too many parts. Expecting '<groupId>:<artifactId>:<version>:<scope>:<type>'");
+      throw new IllegalArgumentException("Too many parts. Expecting '<groupId>:<artifactId>:<version>:<scope>:<type>:<classifier>'");
     }
 
     String[] expanded = new String[NUM_ELEMENTS];
@@ -52,6 +54,7 @@ public final class StyleKey {
     this.scope = expanded[2];
     this.type = expanded[3];
     this.version = expanded[4];
+    this.classifier = expanded[5];
   }
 
   public static StyleKey fromString(String keyString) {
@@ -59,8 +62,8 @@ public final class StyleKey {
     return new StyleKey(parts);
   }
 
-  public static StyleKey create(String groupId, String artifactId, String scope, String type, String version) {
-    return new StyleKey(new String[]{groupId, artifactId, scope, type, version});
+  public static StyleKey create(String groupId, String artifactId, String scope, String type, String version, String classifier) {
+    return new StyleKey(new String[]{groupId, artifactId, scope, type, version, classifier});
   }
 
   public boolean matches(StyleKey other) {
@@ -68,7 +71,8 @@ public final class StyleKey {
         && (wildcardMatch(this.artifactId, other.artifactId))
         && (match(this.scope, other.scope))
         && (match(this.type, other.type))
-        && (wildcardMatch(this.version, other.version));
+        && (wildcardMatch(this.version, other.version))
+        && (wildcardMatch(this.classifier, other.classifier));
 
   }
 
@@ -88,17 +92,18 @@ public final class StyleKey {
         && Objects.equals(this.artifactId, other.artifactId)
         && Objects.equals(this.scope, other.scope)
         && Objects.equals(this.type, other.type)
-        && Objects.equals(this.version, other.version);
+        && Objects.equals(this.version, other.version)
+        && Objects.equals(this.classifier, other.classifier);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.groupId, this.artifactId, this.scope, this.type, this.version);
+    return Objects.hash(this.groupId, this.artifactId, this.scope, this.type, this.version, this.classifier);
   }
 
   @Override
   public String toString() {
-    return Joiner.on(",").join(this.groupId, this.artifactId, this.scope, this.type, this.version);
+    return Joiner.on(",").join(this.groupId, this.artifactId, this.scope, this.type, this.version, this.classifier);
   }
 
   private static boolean wildcardMatch(String value1, String value2) {

--- a/src/test/java/com/github/ferstl/depgraph/dependency/dot/style/StyleConfigurationTest.java
+++ b/src/test/java/com/github/ferstl/depgraph/dependency/dot/style/StyleConfigurationTest.java
@@ -41,12 +41,14 @@ public class StyleConfigurationTest {
   private static final String ARTIFACT_ID = "artifactId";
   private static final String VERSION = "1.0.0";
   private static final String TYPE = "jar";
+  private static final String CLASSIFIER = "classifier";
   private static final String CLASSIFIER_DEFAULT = "";
   private static final String CLASSIFIER_LINUX = "linux";
 
-  private static final StyleKey COMPILE_STYLE_KEY = StyleKey.create(GROUP_ID, ARTIFACT_ID, SCOPE_COMPILE, TYPE, VERSION);
-  private static final StyleKey TEST_STYLE_KEY = StyleKey.create(GROUP_ID, ARTIFACT_ID, SCOPE_TEST, TYPE, VERSION);
-  private static final StyleKey PROVIDED_STYLE_KEY = StyleKey.create(GROUP_ID, ARTIFACT_ID, SCOPE_PROVIDED, TYPE, VERSION);
+  private static final StyleKey COMPILE_STYLE_KEY = StyleKey.create(GROUP_ID, ARTIFACT_ID, SCOPE_COMPILE, TYPE, VERSION, CLASSIFIER_DEFAULT);
+  private static final StyleKey TEST_STYLE_KEY = StyleKey.create(GROUP_ID, ARTIFACT_ID, SCOPE_TEST, TYPE, VERSION, CLASSIFIER_LINUX);
+  private static final StyleKey TEST_STYLE_KEY_CLASSIFIER = StyleKey.create(GROUP_ID, ARTIFACT_ID, SCOPE_TEST, TYPE, VERSION, CLASSIFIER);
+  private static final StyleKey PROVIDED_STYLE_KEY = StyleKey.create(GROUP_ID, ARTIFACT_ID, SCOPE_PROVIDED, TYPE, VERSION, CLASSIFIER_DEFAULT);
 
   private ClasspathStyleResource testStyle;
   private StyleConfiguration emptyConfig;
@@ -74,6 +76,7 @@ public class StyleConfigurationTest {
     assertEquals("[style=\"dashed\"]", config.edgeAttributes(NodeResolution.OMITTED_FOR_DUPLICATE, SCOPE_COMPILE, null, null).toString());
     assertEquals("[label=<groupId<br/>artifactId<br/>1.0.0<br/>jar<br/>compile>]", config.nodeAttributes(COMPILE_STYLE_KEY, GROUP_ID, ARTIFACT_ID, VERSION, TYPE, CLASSIFIER_DEFAULT, SCOPE_COMPILE).toString());
     assertEquals("[shape=\"box\",style=\"filled\",fillcolor=\"orange\",label=<groupId<br/>artifactId<br/>1.0.0<br/>jar<br/>linux<br/>test>]", config.nodeAttributes(TEST_STYLE_KEY, GROUP_ID, ARTIFACT_ID, VERSION, TYPE, CLASSIFIER_LINUX, SCOPE_TEST).toString());
+    assertEquals("[shape=\"polygon\",style=\"filled\",fillcolor=\"green\",label=<groupId<br/>artifactId<br/>1.0.0<br/>jar<br/>classifier<br/>test>]", config.nodeAttributes(TEST_STYLE_KEY_CLASSIFIER, GROUP_ID, ARTIFACT_ID, VERSION, TYPE, CLASSIFIER, SCOPE_TEST).toString());
   }
 
   @Test

--- a/src/test/java/com/github/ferstl/depgraph/dependency/dot/style/StyleKeyTest.java
+++ b/src/test/java/com/github/ferstl/depgraph/dependency/dot/style/StyleKeyTest.java
@@ -31,6 +31,7 @@ public class StyleKeyTest {
   private StyleKey scope;
   private StyleKey type;
   private StyleKey version;
+  private StyleKey classifier;
 
   @Before
   public void before() {
@@ -39,57 +40,63 @@ public class StyleKeyTest {
     this.scope = StyleKey.fromString(",,scope");
     this.type = StyleKey.fromString(",,,type");
     this.version = StyleKey.fromString(",,,,version");
+    this.classifier = StyleKey.fromString(",,,,,classifier");
   }
 
   @Test
   public void fromStringWithGroupIdOnly() {
-    assertEquals("group.id,,,,", this.groupId.toString());
+    assertEquals("group.id,,,,,", this.groupId.toString());
   }
 
   @Test
   public void fromStringWithArtifactIdOnly() {
-    assertEquals(",artifactId,,,", this.artifactId.toString());
+    assertEquals(",artifactId,,,,", this.artifactId.toString());
   }
 
   @Test
   public void fromStringWithScopeOnly() {
-    assertEquals(",,scope,,", this.scope.toString());
+    assertEquals(",,scope,,,", this.scope.toString());
   }
 
   @Test
   public void fromStringWithTypeOnly() {
-    assertEquals(",,,type,", this.type.toString());
+    assertEquals(",,,type,,", this.type.toString());
   }
 
   @Test
   public void fromStringWithVersionOnly() {
-    assertEquals(",,,,version", this.version.toString());
+    assertEquals(",,,,version,", this.version.toString());
+  }
+
+  @Test
+  public void fromStringWithClassifierOnly() {
+    assertEquals(",,,,,classifier", this.classifier.toString());
   }
 
   @Test
   public void fromStringEmpty() {
     StyleKey key = StyleKey.fromString("");
 
-    assertEquals(",,,,", key.toString());
+    assertEquals(",,,,,", key.toString());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void fromStringTooManyParts() {
-    StyleKey.fromString("groupId,artifactId,scope,type,version,something,else");
+    StyleKey.fromString("groupId,artifactId,scope,type,version,something,classifier,else");
   }
 
   @Test
   public void create() {
-    StyleKey key = StyleKey.create("groupId", "artifactId", "scope", "type", "version");
+    StyleKey key = StyleKey.create("groupId", "artifactId", "scope", "type", "version", "classifier");
 
-    assertEquals("groupId,artifactId,scope,type,version", key.toString());
+    assertEquals("groupId,artifactId,scope,type,version,classifier", key.toString());
   }
 
   @Test
   public void createWithNullValues() {
-    StyleKey key = StyleKey.create(null, null, null, null, null);
+    StyleKey key = StyleKey.create(null, null, null, null, null, null);
 
-    assertEquals(",,,,", key.toString());
+    assertEquals(",,,,,", key.toString());
   }
 
   @Test
@@ -147,5 +154,13 @@ public class StyleKeyTest {
 
     assertTrue(this.version.matches(this.version));
     assertTrue(wildcard.matches(this.version));
+  }
+
+  @Test
+  public void matchesForClassifier() {
+    StyleKey wildcard = StyleKey.fromString(",,,,,classifier*");
+
+    assertTrue(this.classifier.matches(this.classifier));
+    assertTrue(wildcard.matches(this.classifier));
   }
 }

--- a/src/test/resources/test-style.json
+++ b/src/test/resources/test-style.json
@@ -25,6 +25,11 @@
     }
   },
   "node-styles" : {
+    ",,,,,classifier" : {
+      "type": "polygon",
+      "style": "filled",
+      "fill-color": "green"
+    },
     ",,test" : {
       "type": "box",
       "style": "filled",


### PR DESCRIPTION
This adds support for using classifier when specifying node styles for
the DOT format. classifier is added as the last parameter in the comma
separated attributes for the style key.