### PR TITLE
Fixed GraphBuilderMatcher and omitReachablePaths implementation

### DIFF
--- a/src/test/java/com/github/ferstl/depgraph/dependency/AggregatingGraphFactoryTest.java
+++ b/src/test/java/com/github/ferstl/depgraph/dependency/AggregatingGraphFactoryTest.java
@@ -118,8 +118,8 @@ public class AggregatingGraphFactoryTest {
             "\"groupId:child1:jar:version:compile\"",
             "\"groupId:child2:jar:version:compile\""},
         new String[]{
-            "\"groupId:parent:jar:version:compile\" -> \"groupId:child1:jar:version:compile\"[style=dotted]",
-            "\"groupId:parent:jar:version:compile\" -> \"groupId:child2:jar:version:compile\"[style=dotted]"}));
+            "\"groupId:parent:jar:version:compile\" -> \"groupId:child1:jar:version:compile\"",
+            "\"groupId:parent:jar:version:compile\" -> \"groupId:child2:jar:version:compile\""}));
   }
 
   /**
@@ -184,11 +184,11 @@ public class AggregatingGraphFactoryTest {
             "\"groupId:child2-1:jar:version:compile\"",
             "\"groupId:child2-2:jar:version:compile\""},
         new String[]{
-            "\"groupId:parent:jar:version:compile\" -> \"groupId:child1-1:jar:version:compile\"[style=dotted]",
-            "\"groupId:parent:jar:version:compile\" -> \"groupId:child1-2:jar:version:compile\"[style=dotted]",
-            "\"groupId:parent:jar:version:compile\" -> \"groupId:subParent:jar:version:compile\"[style=dotted]",
-            "\"groupId:subParent:jar:version:compile\" -> \"groupId:child2-1:jar:version:compile\"[style=dotted]",
-            "\"groupId:subParent:jar:version:compile\" -> \"groupId:child2-2:jar:version:compile\"[style=dotted]"}));
+            "\"groupId:parent:jar:version:compile\" -> \"groupId:child1-1:jar:version:compile\"",
+            "\"groupId:parent:jar:version:compile\" -> \"groupId:child1-2:jar:version:compile\"",
+            "\"groupId:parent:jar:version:compile\" -> \"groupId:subParent:jar:version:compile\"",
+            "\"groupId:subParent:jar:version:compile\" -> \"groupId:child2-1:jar:version:compile\"",
+            "\"groupId:subParent:jar:version:compile\" -> \"groupId:child2-2:jar:version:compile\""}));
   }
 
   /**
@@ -214,7 +214,7 @@ public class AggregatingGraphFactoryTest {
             "\"groupId:parent:jar:version:compile\"",
             "\"groupId:child:jar:version:compile\""},
         new String[]{
-            "\"groupId:parent:jar:version:compile\" -> \"groupId:child1:jar:version:compile\"[style=dotted]"}));
+            "\"groupId:parent:jar:version:compile\" -> \"groupId:child:jar:version:compile\""}));
   }
 
   /**
@@ -250,8 +250,8 @@ public class AggregatingGraphFactoryTest {
             "\"groupId:child1-1:jar:version:compile\"",
             "\"groupId:child1-2:jar:version:compile\""},
         new String[]{
-            "\"groupId:parent:jar:version:compile\" -> \"groupId:child1-1:jar:version:compile\"[style=dotted]",
-            "\"groupId:parent:jar:version:compile\" -> \"groupId:child1-2:jar:version:compile\"[style=dotted]"}));
+            "\"groupId:parent:jar:version:compile\" -> \"groupId:child1-1:jar:version:compile\"",
+            "\"groupId:parent:jar:version:compile\" -> \"groupId:child1-2:jar:version:compile\""}));
   }
 
   /**
@@ -285,7 +285,7 @@ public class AggregatingGraphFactoryTest {
             "\"groupId:parent:jar:version:compile\"",
             "\"groupId:child2:jar:version:compile\""},
         new String[]{
-            "\"groupId:parent:jar:version:compile\" -> \"groupId:child2:jar:version:compile\"[style=dotted]"}));
+            "\"groupId:parent:jar:version:compile\" -> \"groupId:child2:jar:version:compile\""}));
   }
 
 

--- a/src/test/java/com/github/ferstl/depgraph/dependency/GraphBuildingVisitorTest.java
+++ b/src/test/java/com/github/ferstl/depgraph/dependency/GraphBuildingVisitorTest.java
@@ -84,8 +84,8 @@ public class GraphBuildingVisitorTest {
 
     assertThat(this.graphBuilder, hasNodesAndEdges(
         new String[]{
-            "\"groupId:parent:jar:version:compile\"[label=\"groupId:parent:jar:version:compile\"]",
-            "\"groupId:child:jar:version:compile\"[label=\"groupId:child:jar:version:compile\"]"},
+            "\"groupId:parent:jar:version:compile\"",
+            "\"groupId:child:jar:version:compile\""},
         new String[]{
             "\"groupId:parent:jar:version:compile\" -> \"groupId:child:jar:version:compile\""}));
   }
@@ -118,8 +118,8 @@ public class GraphBuildingVisitorTest {
 
     assertThat(this.graphBuilder, hasNodesAndEdges(
         new String[]{
-            "\"groupId:parent:jar:version:compile\"[label=\"groupId:parent:jar:version:compile\"]",
-            "\"groupId:child1:jar:version:compile\"[label=\"groupId:child1:jar:version:compile\"]"},
+            "\"groupId:parent:jar:version:compile\"",
+            "\"groupId:child1:jar:version:compile\""},
         new String[]{
             "\"groupId:parent:jar:version:compile\" -> \"groupId:child1:jar:version:compile\""}));
   }
@@ -152,8 +152,8 @@ public class GraphBuildingVisitorTest {
 
     assertThat(this.graphBuilder, hasNodesAndEdges(
         new String[]{
-            "\"groupId:parent:jar:version:compile\"[label=\"groupId:parent:jar:version:compile\"]",
-            "\"groupId:child2:jar:version:compile\"[label=\"groupId:child2:jar:version:compile\"]"},
+            "\"groupId:parent:jar:version:compile\"",
+            "\"groupId:child2:jar:version:compile\""},
         new String[]{
             "\"groupId:parent:jar:version:compile\" -> \"groupId:child2:jar:version:compile\""}));
   }
@@ -199,10 +199,10 @@ public class GraphBuildingVisitorTest {
 
     assertThat(this.graphBuilder, hasNodesAndEdges(
         new String[]{
-            "\"groupId:parent:jar:version:compile\"[label=\"groupId:parent:jar:version:compile\"]",
-            "\"groupId:child1:jar:version:compile\"[label=\"groupId:child1:jar:version:compile\"]",
-            "\"groupId:child3:jar:version:compile\"[label=\"groupId:child3:jar:version:compile\"]",
-            "\"groupId:child4:jar:version:compile\"[label=\"groupId:child4:jar:version:compile\"]"},
+            "\"groupId:parent:jar:version:compile\"",
+            "\"groupId:child1:jar:version:compile\"",
+            "\"groupId:child3:jar:version:compile\"",
+            "\"groupId:child4:jar:version:compile\""},
         new String[]{
             "\"groupId:parent:jar:version:compile\" -> \"groupId:child1:jar:version:compile\"",
             "\"groupId:parent:jar:version:compile\" -> \"groupId:child3:jar:version:compile\"",

--- a/src/test/java/com/github/ferstl/depgraph/dependency/GraphBuildingVisitorTest.java
+++ b/src/test/java/com/github/ferstl/depgraph/dependency/GraphBuildingVisitorTest.java
@@ -242,6 +242,9 @@ public class GraphBuildingVisitorTest {
 
     assertTrue(visitor.visitEnter(nodeA));
 
+    assertTrue(visitor.visitEnter(nodeD));
+    assertTrue(visitor.visitLeave(nodeD));
+
     assertTrue(visitor.visitEnter(nodeB));
     assertTrue(visitor.visitEnter(nodeD));
     assertTrue(visitor.visitLeave(nodeD));
@@ -253,9 +256,6 @@ public class GraphBuildingVisitorTest {
     assertTrue(visitor.visitEnter(nodeD));
     assertTrue(visitor.visitLeave(nodeD));
     assertTrue(visitor.visitLeave(nodeC));
-
-    assertTrue(visitor.visitEnter(nodeD));
-    assertTrue(visitor.visitLeave(nodeD));
 
     assertTrue(visitor.visitEnter(nodeTest));
     assertTrue(visitor.visitLeave(nodeTest));
@@ -280,7 +280,6 @@ public class GraphBuildingVisitorTest {
         }
     ));
   }
-
 
   private static org.eclipse.aether.graph.DependencyNode createMavenDependencyNode(String artifactId, org.eclipse.aether.graph.DependencyNode... children) {
     Dependency dependency = new Dependency(createArtifact(artifactId), "compile");

--- a/src/test/java/com/github/ferstl/depgraph/graph/GraphBuilderMatcher.java
+++ b/src/test/java/com/github/ferstl/depgraph/graph/GraphBuilderMatcher.java
@@ -96,7 +96,7 @@ public final class GraphBuilderMatcher extends TypeSafeDiagnosingMatcher<GraphBu
     }
 
     return containsInAnyOrder(this.expectedNodes).matches(this.nodes)
-        | containsInAnyOrder(this.expectedEdges).matches(this.edges);
+        && containsInAnyOrder(this.expectedEdges).matches(this.edges);
   }
 
   private void init(GraphBuilder<DependencyNode> graphBuilder) {

--- a/src/test/java/com/github/ferstl/depgraph/graph/GraphBuilderTest.java
+++ b/src/test/java/com/github/ferstl/depgraph/graph/GraphBuilderTest.java
@@ -214,35 +214,27 @@ public class GraphBuilderTest {
     assertFalse(this.graphBuilder.isEmpty());
   }
 
+
   @Test
-  public void isReachable() {
+  public void hasAlternativePath() {
     // arrange
     this.graphBuilder.addEdge("A", "B");
     this.graphBuilder.addEdge("B", "D");
-    this.graphBuilder.addEdge("D", "E");
-    this.graphBuilder.addEdge("A", "C");
+    this.graphBuilder.addEdge("A", "D");
 
     // assert
-    assertTrue(this.graphBuilder.isReachable("E", "A"));
-    assertTrue(this.graphBuilder.isReachable("D", "A"));
-    assertTrue(this.graphBuilder.isReachable("C", "A"));
-    assertTrue(this.graphBuilder.isReachable("B", "A"));
-
-    assertFalse(this.graphBuilder.isReachable("C", "B"));
+    assertTrue(this.graphBuilder.hasAlternativePath(new Edge("A", "D", "AD")));
   }
 
   @Test
-  public void isReachableWithCycle() {
+  public void hasAlternativePathWithCycle() {
     // arrange
     this.graphBuilder.addEdge("A", "B");
     this.graphBuilder.addEdge("B", "C");
     this.graphBuilder.addEdge("C", "A");
 
     // assert
-    assertFalse(this.graphBuilder.isReachable("B", "X"));
-
-    assertTrue(this.graphBuilder.isReachable("C", "A"));
-    assertTrue(this.graphBuilder.isReachable("B", "A"));
+    assertFalse(this.graphBuilder.hasAlternativePath(new Edge("B", "X", "BX")));
   }
 
   enum TestNodeRenderer implements NodeRenderer<String> {

--- a/src/test/projects/depgraph-maven-plugin-test/expectations/aggregate_transitive-excludes.txt
+++ b/src/test/projects/depgraph-maven-plugin-test/expectations/aggregate_transitive-excludes.txt
@@ -1,11 +1,10 @@
 com.github.ferstl:module-3:compile
-+- com.github.ferstl:module-1:compile
-|  +- commons-codec:commons-codec:compile
-|  +- org.apache.commons:commons-lang3:compile
-|  \- junit:junit:test
-|     \- org.hamcrest:hamcrest-core:test
 +- com.github.ferstl:module-2:compile
 |  +- com.github.ferstl:module-1:compile
+|  |  +- commons-codec:commons-codec:compile
+|  |  +- org.apache.commons:commons-lang3:compile
+|  |  \- junit:junit:test
+|  |     \- org.hamcrest:hamcrest-core:test
 |  +- com.google.guava:guava:compile
 |  +- org.springframework:spring-core:compile (optional)
 |  \- junit:junit:test

--- a/src/test/projects/optional-dependencies/expectations/aggregate_graph.dot
+++ b/src/test/projects/optional-dependencies/expectations/aggregate_graph.dot
@@ -7,7 +7,7 @@ digraph "optional-test" {
   "org.apache.commons:commons-lang3:jar:compile"[label=<<font point-size="10">&lt;optional&gt;</font><br/>commons-lang3>]
   "commons-codec:commons-codec:jar:compile"[label=<commons-codec>]
   "com.github.ferstl:module-c:jar:compile"[label=<module-c>]
-  "com.github.ferstl:module-a:jar:compile"[label=<module-a>]
+  "com.github.ferstl:module-a:jar:compile"[label=<<font point-size="10">&lt;optional&gt;</font><br/>module-a>]
   "com.github.ferstl:module-d:jar:compile"[label=<module-d>]
   "com.github.ferstl:module-test:jar:compile"[label=<module-test>]
 
@@ -18,6 +18,5 @@ digraph "optional-test" {
   "com.github.ferstl:module-a:jar:compile" -> "com.github.ferstl:module-b:jar:compile"
   "com.github.ferstl:module-a:jar:compile" -> "com.github.ferstl:module-c:jar:compile"
   "com.github.ferstl:module-d:jar:compile" -> "com.github.ferstl:module-a:jar:compile"
-  "com.github.ferstl:module-test:jar:compile" -> "com.github.ferstl:module-c:jar:compile"
   "com.github.ferstl:module-test:jar:compile" -> "com.github.ferstl:module-d:jar:compile"
 }


### PR DESCRIPTION
Fixed error in GraphBuilderMatcher which incorrectly matched if either nodes or edges were equal, instead requiring both to match.

Changed omitReachablePaths implementation in GraphBuilderVisitor so that it remove edges after the graph is created, previously it would only detect duplicate paths if nodes were added in a specific order.