### PR TITLE
#159 Fix ConcurrentModificationException in the text graph

### DIFF
--- a/src/main/java/com/github/ferstl/depgraph/graph/text/TextGraphFormatter.java
+++ b/src/main/java/com/github/ferstl/depgraph/graph/text/TextGraphFormatter.java
@@ -101,7 +101,9 @@ public class TextGraphFormatter implements com.github.ferstl.depgraph.graph.Grap
 
     private void writeChildren(StringBuilder stringBuilder, String parent, Set<String> currentPath, List<Boolean> lastParents) {
       Collection<Edge> edges = this.relations.get(parent);
-      Iterator<Edge> edgeIterator = edges.iterator();
+      // Prevent ConcurrentModificationException (see #159)
+      Collection<Edge> edgesCopy = new ArrayList<>(edges);
+      Iterator<Edge> edgeIterator = edgesCopy.iterator();
 
       while (edgeIterator.hasNext()) {
         Edge edge = edgeIterator.next();


### PR DESCRIPTION
Enabling `showDuplicates` and/or `showConflicts` introduces cycles in the
dependency graph which could cause the recursive method `writeChildren()`
to clear the list of edges while still iterating over it. Creating a copy
of the list for iteration will solve this problem.

Signed-off-by: Stefan Ferstl <st.ferstl@gmail.com>