### PR TITLE
Fix tests to maintain String order

### DIFF
--- a/src/main/java/com/github/ferstl/depgraph/dependency/json/JsonDependencyNodeNameRenderer.java
+++ b/src/main/java/com/github/ferstl/depgraph/dependency/json/JsonDependencyNodeNameRenderer.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Collection;
 import org.apache.maven.artifact.Artifact;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.ferstl.depgraph.dependency.DependencyNode;
 import com.github.ferstl.depgraph.graph.NodeRenderer;
@@ -77,7 +78,7 @@ public class JsonDependencyNodeNameRenderer implements NodeRenderer<DependencyNo
     return jsonStringWriter.toString();
   }
 
-
+  @JsonPropertyOrder(value = {"groupId", "artifactId", "version", "optional", "classifiers", "scopes", "types"})
   private static class ArtifactData {
 
     private final String groupId;


### PR DESCRIPTION
**What is the purpose of the change**
To address the [validation issue](https://github.com/ferstl/depgraph-maven-plugin/issues/177) created due to the potential variations in String ordering during comparison.

This PR aims to fix 18 tests:
```
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderArtifactId
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderArtifactIdVersion
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderArtifactIdVersionOptional
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderJarTypeOnly
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderGroupIdArtifactIdOptional
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderGroupIdArtifactIdVersion
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderGroupIdArtifactIdVersionOptional
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderGroupIdVersion
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderTypes
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderGroupId
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderGroupIdVersionOptional
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderGroupIdArtifactId
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.omitScope
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderAll
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderOptional
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderClassifiers
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderVersion
com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest.renderEmptyClassifier
```


**REASON AND FIX:**

The issue arises while creating a custom node `createDependencyNode` with the specified order which doesn’t match with the order of elements initialized in the class `ArtifactData`. 

https://github.com/ferstl/depgraph-maven-plugin/blob/f93bf3b39986dd7eafff30f5858439a9879e1618/src/test/java/com/github/ferstl/depgraph/dependency/AbstractDependencyNodeNameRendererTest.java#L56

Due to this, validating the String with another string doesn’t turn out to return true.
The fix is to use a `@JsonPropertyOrder` annotation to specify the order in which the properties of the ArtifactData class should always appear in the order specified.

**REPRODUCE:**
This was found by using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. 

```
cd depgraph-maven-plugin
mvn install -am -DskipTests
mvn edu.illinois:nondex-maven-plugin2.1.7-SNAPSHOT:nondex -Dtest=com.github.ferstl.depgraph.dependency.json.JsonDependencyNodeNameRendererTest#renderArtifactIdVersion
```
