### PR TITLE
Multiple wildcard matching for .dot styles

### DIFF
--- a/src/main/java/com/github/ferstl/depgraph/dependency/dot/style/StyleKey.java
+++ b/src/main/java/com/github/ferstl/depgraph/dependency/dot/style/StyleKey.java
@@ -109,15 +109,24 @@ public final class StyleKey {
   }
 
   private static boolean wildcardMatch(String value1, String value2) {
-    if (StringUtils.endsWith(value1, "*")) {
-      return startsWith(value2, value1.substring(0, value1.length() - 1));
+    if (value1.indexOf('*') != -1) {
+      int lastMatch = 0;
+      for (String matchStr : value1.split("\\*")) {
+        int indexOfMatch = value2.substring(lastMatch).indexOf(matchStr);
+        lastMatch += indexOfMatch + matchStr.length();
+        if (indexOfMatch == -1) {
+          return false;
+        }
+      }
+      return true;
     }
 
     return match(value1, value2);
   }
-
+  
   private static boolean match(String value1, String value2) {
     return value1.isEmpty() || value1.equals(value2);
   }
+
 
 }

--- a/src/main/java/com/github/ferstl/depgraph/dependency/dot/style/StyleKey.java
+++ b/src/main/java/com/github/ferstl/depgraph/dependency/dot/style/StyleKey.java
@@ -111,22 +111,24 @@ public final class StyleKey {
   private static boolean wildcardMatch(String value1, String value2) {
     if (value1.indexOf('*') != -1) {
       int lastMatch = 0;
+      
       for (String matchStr : value1.split("\\*")) {
         int indexOfMatch = value2.substring(lastMatch).indexOf(matchStr);
         lastMatch += indexOfMatch + matchStr.length();
+        
         if (indexOfMatch == -1) {
           return false;
         }
       }
+      
       return true;
     }
 
     return match(value1, value2);
   }
-  
+
   private static boolean match(String value1, String value2) {
     return value1.isEmpty() || value1.equals(value2);
   }
-
 
 }

--- a/src/test/java/com/github/ferstl/depgraph/dependency/dot/style/StyleKeyTest.java
+++ b/src/test/java/com/github/ferstl/depgraph/dependency/dot/style/StyleKeyTest.java
@@ -180,4 +180,12 @@ class StyleKeyTest {
     assertTrue(this.optional.matches(this.optional));
     assertFalse(unsupportedWildcard.matches(this.optional));
   }
+
+  @Test
+  void matchesForWildcard() {
+    StyleKey styleKey = StyleKey.fromString("groupId,artifactId,scope,type,version,classifier,optional");
+    StyleKey wildcard = StyleKey.fromString("gr*Id,*tifa*Id,,,versi**on,*ssif*,");
+
+    assertTrue(wildcard.matches(styleKey));
+  }
 }


### PR DESCRIPTION
Hi there! I've made some changes to the `wildcardMatch` method in your .dot style code to allow for asterisk wildcard matching not just at the end of the string, but for any substring, and for multiple wildcards. For example, this could help match SNAPSHOT version numbers with the following: `*-SNAPSHOT`

Here's what I've done:

- updated the `wildcardMatch` method to split the string at `*`, then step through the resultant string array to see if they appear in sequence in the comparative string

If you want any extra info give me a shout.